### PR TITLE
Fix beforeTraverse with Func->cfg being null

### DIFF
--- a/lib/PHPCfg/AbstractVisitor.php
+++ b/lib/PHPCfg/AbstractVisitor.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of PHP-CFG, a Control flow graph implementation for PHP
+ *
+ * @copyright 2015 Anthony Ferrara. All rights reserved
+ * @license MIT See LICENSE at the root of the project for more info
+ */
+
+namespace PHPCfg;
+
+/**
+ * Dummy visitor implementation.
+ *
+ * To avoid repeating empty method bodies for the unused parts.
+ */
+abstract class AbstractVisitor implements Visitor {
+    public function enterFunc(Func $block) {}
+    public function leaveFunc(Func $block) {}
+
+    public function enterBlock(Block $block, Block $prior = null) {}
+    public function leaveBlock(Block $block, Block $prior = null) {}
+    public function skipBlock(Block $block, Block $prior = null) {}
+
+    public function enterOp(Op $op, Block $block) {}
+    public function leaveOp(Op $op, Block $block) {}
+}

--- a/lib/PHPCfg/Func.php
+++ b/lib/PHPCfg/Func.php
@@ -16,7 +16,7 @@ class Func {
     public $returnsRef;
     /** @var */
     public $returnType;
-    /** @var */
+    /** @var Operand\Literal */
     public $class;
     /** @var Op\Expr\Param[] */
     public $params;
@@ -30,5 +30,13 @@ class Func {
         $this->class = $class;
         $this->params = [];
         $this->cfg = new Block;
+    }
+
+    public function getScopedName() {
+        if (null !== $this->class) {
+            return $this->class->value . '::' . $this->name;
+        }
+
+        return $this->name;
     }
 }

--- a/lib/PHPCfg/Op/Terminal/Const_.php
+++ b/lib/PHPCfg/Op/Terminal/Const_.php
@@ -14,6 +14,7 @@ use PHPCfg\Operand;
 use PHPCfg\Block;
 
 class Const_ extends Terminal {
+    /** @var Operand\Literal */
     public $name;
     public $value;
     public $valueBlock;

--- a/lib/PHPCfg/Printer/GraphViz.php
+++ b/lib/PHPCfg/Printer/GraphViz.php
@@ -48,9 +48,9 @@ class GraphViz extends Printer {
     }
 
     protected function printFuncWithHeader(Func $func, Graph $graph, $prefix) {
-        $scope = $func->class ? $func->class->value . '::' : '';
+        $name = $func->getScopedName();
         $header = $this->createNode(
-            $prefix . 'header', "Function $scope$func->name():"
+            $prefix . 'header', "Function $name():"
         );
         $graph->setNode($header);
 

--- a/lib/PHPCfg/Printer/Text.php
+++ b/lib/PHPCfg/Printer/Text.php
@@ -18,8 +18,8 @@ class Text extends Printer {
         $output = '';
         $output .= $this->printFunc($script->main);
         foreach ($script->functions as $func) {
-            $scope = $func->class ? $func->class->value . '::' : '';
-            $output .= "\nFunction $scope$func->name():";
+            $name = $func->getScopedName();
+            $output .= "\nFunction $name():";
             $output .= $this->printFunc($func);
         }
         return $output;

--- a/lib/PHPCfg/Traverser.php
+++ b/lib/PHPCfg/Traverser.php
@@ -31,14 +31,14 @@ class Traverser {
     private function traverseFunc(Func $func) {
         $this->seen = new \SplObjectStorage;
         $block = $func->cfg;
-        $this->event("beforeTraverse", [$block]);
+        $this->event("enterFunc", [$func]);
         $result = $this->traverseBlock($block, null);
         if ($result === Visitor::REMOVE_BLOCK) {
             throw new \RuntimeException("Cannot remove function start block");
         } elseif (!is_null($result)) {
             $block = $result;
         }
-        $this->event("afterTraverse", [$block]);
+        $this->event("leaveFunc", [$func]);
         $func->cfg = $block;
     }
 

--- a/lib/PHPCfg/Visitor.php
+++ b/lib/PHPCfg/Visitor.php
@@ -14,9 +14,9 @@ interface Visitor {
     const REMOVE_OP = -1;
     const REMOVE_BLOCK = -2;
 
-    public function beforeTraverse(Block $block);
+    public function enterFunc(Func $block);
 
-    public function afterTraverse(Block $block);
+    public function leaveFunc(Func $block);
     
     public function enterBlock(Block $block, Block $prior = null);
 
@@ -27,7 +27,5 @@ interface Visitor {
     public function leaveBlock(Block $block, Block $prior = null);
 
     public function skipBlock(Block $block, Block $prior = null);
-
-
 
 }

--- a/lib/PHPCfg/Visitor/CallFinder.php
+++ b/lib/PHPCfg/Visitor/CallFinder.php
@@ -12,9 +12,9 @@ namespace PHPCfg\Visitor;
 use PHPCfg\Block;
 use PHPCfg\Op;
 use PHPCfg\Operand;
-use PHPCfg\Visitor;
+use PHPCfg\AbstractVisitor;
 
-class CallFinder implements Visitor {
+class CallFinder extends AbstractVisitor {
     
     protected $calls = [];
     protected $funcStack = [];
@@ -24,8 +24,6 @@ class CallFinder implements Visitor {
         $func = strtolower($func);
         return isset($this->calls[$func]) ? $this->calls[$func] : [];
     }
-
-    public function enterBlock(Block $block, Block $prior = null) {}
 
     public function enterOp(Op $op, Block $block) {
         if ($op instanceof Op\CallableOp) {
@@ -47,13 +45,5 @@ class CallFinder implements Visitor {
             $this->func = array_pop($this->funcStack);
         }
     }
-
-    public function leaveBlock(Block $block, Block $prior = null) {}
-
-    public function skipBlock(Block $block, Block $prior = null) {}
-
-    public function beforeTraverse(Block $block) {}
-
-    public function afterTraverse(Block $block) {}
 
 }

--- a/lib/PHPCfg/Visitor/DebugVisitor.php
+++ b/lib/PHPCfg/Visitor/DebugVisitor.php
@@ -10,11 +10,13 @@
 namespace PHPCfg\Visitor;
 
 use PHPCfg\Block;
+use PHPCfg\Func;
 use PHPCfg\Op;
 use PHPCfg\Visitor;
 
 class DebugVisitor implements Visitor {
 
+    /** @var \SplObjectStorage */
     protected $blocks;
 
     public function enterBlock(Block $block, Block $prior = null) {
@@ -37,13 +39,13 @@ class DebugVisitor implements Visitor {
         echo "Skip Block #" . $this->getBlockId($block) . "\n";
     }
 
-    public function beforeTraverse(Block $block) {
+    public function enterFunc(Func $func) {
         $this->blocks = new \SplObjectStorage;
-        echo "Before Traverse Block #" . $this->getBlockId($block) . "\n";
+        echo "Enter Func " . $func->getScopedName() . "\n";
     }
 
-    public function afterTraverse(Block $block) {
-        echo "After Traverse Block #" . $this->getBlockId($block) . "\n";
+    public function leaveFunc(Func $func) {
+        echo "Leave Func " . $func->getScopedName() . "\n";
         $this->blocks = null;
     }
 

--- a/lib/PHPCfg/Visitor/DeclarationFinder.php
+++ b/lib/PHPCfg/Visitor/DeclarationFinder.php
@@ -11,9 +11,9 @@ namespace PHPCfg\Visitor;
 
 use PHPCfg\Block;
 use PHPCfg\Op;
-use PHPCfg\Visitor;
+use PHPCfg\AbstractVisitor;
 
-class DeclarationFinder implements Visitor {
+class DeclarationFinder extends AbstractVisitor {
     
     protected $traits = [];
     protected $classes = [];
@@ -46,8 +46,6 @@ class DeclarationFinder implements Visitor {
         return $this->interfaces;
     }
 
-    public function enterBlock(Block $block, Block $prior = null) {}
-
     public function enterOp(Op $op, Block $block) {
         if ($op instanceof Op\Stmt\Trait_) {
             $this->traits[] = $op;
@@ -66,15 +64,5 @@ class DeclarationFinder implements Visitor {
             $this->constants[$op->name->value][] = $op;
         }
     }
-
-    public function leaveOp(Op $op, Block $block) {}
-
-    public function leaveBlock(Block $block, Block $prior = null) {}
-
-    public function skipBlock(Block $block, Block $prior = null) {}
-
-    public function beforeTraverse(Block $block) {}
-
-    public function afterTraverse(Block $block) {}
 
 }

--- a/lib/PHPCfg/Visitor/VariableFinder.php
+++ b/lib/PHPCfg/Visitor/VariableFinder.php
@@ -11,9 +11,9 @@ namespace PHPCfg\Visitor;
 
 use PHPCfg\Block;
 use PHPCfg\Op;
-use PHPCfg\Visitor;
+use PHPCfg\AbstractVisitor;
 
-class VariableFinder implements Visitor{
+class VariableFinder extends AbstractVisitor {
     protected $variables;
 
     public function __construct() {
@@ -22,12 +22,6 @@ class VariableFinder implements Visitor{
 
     public function getVariables() {
         return $this->variables;
-    }
-
-    public function beforeTraverse(Block $block) {
-    }
-
-    public function afterTraverse(Block $block) {
     }
 
     public function enterBlock(Block $block, Block $prior = null) {
@@ -49,15 +43,6 @@ class VariableFinder implements Visitor{
                 $this->variables->attach($v);
             }
         }
-    }
-
-    public function leaveOp(Op $op, Block $block) {
-    }
-
-    public function leaveBlock(Block $block, Block $prior = null) {
-    }
-
-    public function skipBlock(Block $block, Block $prior = null) {
     }
 
 }


### PR DESCRIPTION
Renamed before/afterTraverse to enter/leaveFunc and pass Func
object instead of Block.

Also add AbstractVisitor as a base class for visitors.
