### PR TITLE
public traverseFunc and enter/leaveScript in Traverser (#22)

### DIFF
--- a/lib/PHPCfg/AbstractVisitor.php
+++ b/lib/PHPCfg/AbstractVisitor.php
@@ -15,6 +15,9 @@ namespace PHPCfg;
  * To avoid repeating empty method bodies for the unused parts.
  */
 abstract class AbstractVisitor implements Visitor {
+    public function enterScript(Script $script) {}
+    public function leaveScript(Script $script) {}
+
     public function enterFunc(Func $block) {}
     public function leaveFunc(Func $block) {}
 

--- a/lib/PHPCfg/Traverser.php
+++ b/lib/PHPCfg/Traverser.php
@@ -21,14 +21,15 @@ class Traverser {
     }
 
     public function traverse(Script $script) {
+        $this->event('enterScript', [$script]);
         $this->traverseFunc($script->main);
         foreach ($script->functions as $func) {
             $this->traverseFunc($func);
         }
-        $this->seen = null;
+        $this->event('leaveScript', [$script]);
     }
 
-    private function traverseFunc(Func $func) {
+    public function traverseFunc(Func $func) {
         $this->seen = new \SplObjectStorage;
         $this->event("enterFunc", [$func]);
         $block = $func->cfg;
@@ -42,6 +43,7 @@ class Traverser {
             $func->cfg = $block;
         }
         $this->event("leaveFunc", [$func]);
+        $this->seen = null;
     }
 
     private function traverseBlock(Block $block, Block $prior = null) {

--- a/lib/PHPCfg/Visitor.php
+++ b/lib/PHPCfg/Visitor.php
@@ -14,6 +14,10 @@ interface Visitor {
     const REMOVE_OP = -1;
     const REMOVE_BLOCK = -2;
 
+    public function enterScript(Script $script);
+
+    public function leaveScript(Script $script);
+
     public function enterFunc(Func $block);
 
     public function leaveFunc(Func $block);


### PR DESCRIPTION
Made traverseFunc method public and added enterScript and leaveScript events as extension points for before and after script traversal hooks
- moved resetting of $this->seen to traverseFunc, to ensure it gets reset when traversing only a Func
